### PR TITLE
Fix broker partition info logic introduced by hack 8c2369c45e85d1f8ba95e...

### DIFF
--- a/core/src/main/scala/kafka/producer/ZKBrokerPartitionInfo.scala
+++ b/core/src/main/scala/kafka/producer/ZKBrokerPartitionInfo.scala
@@ -168,10 +168,7 @@ private[producer] class ZKBrokerPartitionInfo(config: ZKConfig, producerCbk: (In
       val brokerTopicPath = ZkUtils.BrokerTopicsPath + "/" + topic
       val brokerList = ZkUtils.getChildrenParentMayNotExist(zkClient, brokerTopicPath)
 
-      val numPartitions = brokerList.map{bid =>
-        val x = ZkUtils.readData(zkClient, brokerTopicPath + "/" + bid)
-        if (x == "") 0 else bid.toInt
-      }
+      val numPartitions = brokerList.map { bid => ZkUtils.readData(zkClient, brokerTopicPath + "/" + bid).toInt }
 
       val brokerPartitions = brokerList.map(bid => bid.toInt).zip(numPartitions)
       val sortedBrokerPartitions = brokerPartitions.sortWith((id1, id2) => id1._1 < id2._1)


### PR DESCRIPTION
...89f23fb7aaf4bc15731

Without this, the list of partitions returned is strictly equal to the brokerId, which is definitely wrong.
